### PR TITLE
Allow overriding ZFS install base dir on cmake command line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,19 @@
 cmake_minimum_required (VERSION 3.7)
 project (zpool_influxdb C)
 
-# By default, ZFSonLinux installs the necessary header files and libraries
-# in /usr/local. If this is not the case for your system, change INSTALL_DIR
-set(INSTALL_DIR /usr/local)
+# By default, ZFSonLinux installs the necessary header files and
+# libraries in /usr/local. If this is not the case for your system,
+# set ZFS_INSTALL_BASE, e.g. for the Ubuntu zfs-on-linux library, use:
+#      -D ZFS_INSTALL_BASE=/usr
+# on the cmake command-line.
+set(ZFS_INSTALL_BASE /usr/local CACHE STRING "zfs installation base directory")
 
 # to support unsigned 64-bit ints properly, uncomment below to set the
 # SUPPORT_UINT64 flag at compile time
-#set(CMAKE_C_FLAGS "-DSUPPORT_UINT64")
+set(CMAKE_C_FLAGS "-DSUPPORT_UINT64")
 
-include_directories(${INSTALL_DIR}/include/libspl ${INSTALL_DIR}/include/libzfs)
-link_directories(${INSTALL_DIR}/lib)
+include_directories(${ZFS_INSTALL_BASE}/include/libspl ${ZFS_INSTALL_BASE}/include/libzfs)
+link_directories(${ZFS_INSTALL_BASE}/lib)
 add_executable(zpool_influxdb zpool_influxdb.c)
 target_link_libraries(zpool_influxdb zfs nvpair)
-install(TARGETS zpool_influxdb DESTINATION ${INSTALL_DIR}/bin)
+install(TARGETS zpool_influxdb DESTINATION ${ZFS_INSTALL_BASE}/bin)

--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ Building is simplified by using cmake.
 It is as simple as possible, but no simpler.
 By default, [ZFSonLinux](https://github.com/zfsonlinux/zfs) 
 installs the necessary header and library files in _/usr/local_.
-If you place those files elsewhere, then edit _CMakeLists.txt_ and
-change the _INSTALL_DIR_
+If you place those files elsewhere, either edit _CMakeLists.txt_ and
+change the _ZFS_INSTALL_BASE_ or pass it with `-D ZFS_INSTALL_BASE=/usr`
+on the cmake command line:
 ```bash
 cmake .
 make


### PR DESCRIPTION
I'm trying to build zpool_influxdb for an Ubuntu system in a CI-like environment, and would love to not have to override the directory without modifying a checked-in file. So, since cmake supports build arguments, I figured that we could use them in order to get a cleaner build process. With it, I can build the tool on a basic Ubuntu install with just `cmake -D ZFS_INSTALL_BASE=/usr . && make`

In the process, I renamed install base directory variable too, to hopefully make it clearer to users what it is all about.

Hope you find this patch useful!