### PR TITLE
Build against modern OpenZFS (2.1-2.4); add polling-safety options and pool I/O rates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# cmake in-source build artifacts
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+
+# built executable
+/zpool_influxdb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,55 @@
 cmake_minimum_required (VERSION 3.7)
 project (zpool_influxdb C)
 
-# By default, ZFSonLinux installs the necessary header files and
-# libraries in /usr/local. If this is not the case for your system,
-# set ZFS_INSTALL_BASE, e.g. for the Ubuntu zfs-on-linux library, use:
-#      -D ZFS_INSTALL_BASE=/usr
-# on the cmake command-line.
-set(ZFS_INSTALL_BASE /usr/local CACHE STRING "zfs installation base directory")
+include(CheckCSourceCompiles)
+
+# Distribution packages (Debian/Ubuntu zfsutils-linux, Arch/CachyOS, etc.)
+# install the libzfs headers and libraries under /usr. Source installs of
+# ZFSonLinux default to /usr/local. Override on the cmake command-line if
+# yours differs, e.g.:
+#      -D ZFS_INSTALL_BASE=/usr/local
+set(ZFS_INSTALL_BASE /usr CACHE STRING "zfs installation base directory")
+
+# Target CPU microarchitecture. Defaults to x86-64-v4 (AVX-512 baseline).
+# NOTE: a v4 binary will SIGILL on CPUs older than x86-64-v4. To build a
+# portable binary, or target a different level, override on the command line:
+#      -D TARGET_ARCH=x86-64-v3      (AVX2 baseline)
+#      -D TARGET_ARCH=               (compiler default, most portable)
+set(TARGET_ARCH "x86-64-v4" CACHE STRING "value passed to the compiler -march= flag")
 
 # to support unsigned 64-bit ints properly, uncomment below to set the
-# SUPPORT_UINT64 flag at compile time
-set(CMAKE_C_FLAGS "-DSUPPORT_UINT64")
+# SUPPORT_UINT64 flag at compile time.
+# _LARGEFILE64_SOURCE is required so that the libspl headers can use the
+# transitional stat64()/fstat64() interfaces with modern glibc.
+set(CMAKE_C_FLAGS "-DSUPPORT_UINT64 -D_LARGEFILE64_SOURCE")
+if(TARGET_ARCH)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=${TARGET_ARCH}")
+endif()
 
 include_directories(${ZFS_INSTALL_BASE}/include/libspl ${ZFS_INSTALL_BASE}/include/libzfs)
 link_directories(${ZFS_INSTALL_BASE}/lib)
+
+# The third argument of nvlist_lookup_string() gained a const qualifier in
+# OpenZFS 2.2. Detect which signature this libzfs uses so the source can match
+# it and build cleanly on both old (e.g. Debian 12 / ZFS 2.1) and new headers.
+set(CMAKE_REQUIRED_INCLUDES ${ZFS_INSTALL_BASE}/include/libspl ${ZFS_INSTALL_BASE}/include/libzfs)
+set(CMAKE_REQUIRED_FLAGS "-Werror -D_LARGEFILE64_SOURCE")
+# Compile only (build a static lib): the test references nvlist_lookup_string
+# but we don't want to require linking libnvpair just to probe its signature.
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+check_c_source_compiles("
+#include <libnvpair.h>
+int probe(nvlist_t *nv) {
+    const char *s;
+    return nvlist_lookup_string(nv, \"x\", &s);
+}" HAVE_CONST_NVLIST_LOOKUP_STRING)
+unset(CMAKE_TRY_COMPILE_TARGET_TYPE)
+unset(CMAKE_REQUIRED_FLAGS)
+unset(CMAKE_REQUIRED_INCLUDES)
+if(HAVE_CONST_NVLIST_LOOKUP_STRING)
+    add_definitions(-DHAVE_CONST_NVLIST_LOOKUP_STRING)
+endif()
+
 add_executable(zpool_influxdb zpool_influxdb.c)
 target_link_libraries(zpool_influxdb zfs nvpair)
 set_property(TARGET zpool_influxdb PROPERTY C_STANDARD 99)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,19 @@ set(ZFS_INSTALL_BASE /usr CACHE STRING "zfs installation base directory")
 #      -D TARGET_ARCH=               (compiler default, most portable)
 set(TARGET_ARCH "x86-64-v4" CACHE STRING "value passed to the compiler -march= flag")
 
+# When building on a host whose toolchain stamps a higher x86-64 ISA level into
+# the binary than the deployment target supports -- e.g. building on an
+# x86-64-v4 distro variant (such as CachyOS) for a v3 CPU -- the glibc loader
+# can refuse the binary at startup with "CPU ISA level is lower than required",
+# even with TARGET_ARCH set correctly. That requirement is inherited from the
+# system startup objects (the GNU_PROPERTY_X86_ISA_1_NEEDED note), not your
+# code. Enable this to strip .note.gnu.property after linking so the loader
+# does not enforce an ISA level; the code still only uses TARGET_ARCH
+# instructions. (Prefer building on a host whose baseline ISA is <= the target
+# when you can; this is the escape hatch when you cannot.)
+option(STRIP_ISA_PROPERTY
+       "strip .note.gnu.property so the binary is not gated to the build host's ISA level" OFF)
+
 # to support unsigned 64-bit ints properly, uncomment below to set the
 # SUPPORT_UINT64 flag at compile time.
 # _LARGEFILE64_SOURCE is required so that the libspl headers can use the
@@ -53,4 +66,19 @@ endif()
 add_executable(zpool_influxdb zpool_influxdb.c)
 target_link_libraries(zpool_influxdb zfs nvpair)
 set_property(TARGET zpool_influxdb PROPERTY C_STANDARD 99)
+
+if(STRIP_ISA_PROPERTY)
+    find_program(OBJCOPY NAMES objcopy)
+    if(OBJCOPY)
+        add_custom_command(TARGET zpool_influxdb POST_BUILD
+            COMMAND ${OBJCOPY} --remove-section=.note.gnu.property
+                    $<TARGET_FILE:zpool_influxdb>
+            COMMENT "Stripping .note.gnu.property (build-host ISA level gate)")
+    else()
+        message(WARNING
+            "STRIP_ISA_PROPERTY is ON but objcopy was not found; the binary "
+            "may carry the build host's ISA requirement.")
+    endif()
+endif()
+
 install(TARGETS zpool_influxdb DESTINATION ${ZFS_INSTALL_BASE}/bin)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Relative to the upstream repository:
   instance; skip overlapping invocations) and `--timeout` (bound a slow
   sample) options make frequent collection (e.g. telegraf every few seconds)
   safer. See [Caveat Emptor](#caveat-emptor).
+* **Pool I/O rates.** New `--iostat-interval` option emits a `zpool_iostat`
+  measurement with per-second read/write throughput (KiB/s) and IOPS for the
+  pool, computed like `zpool iostat`. See
+  [zpool_iostat Description](#zpool_iostat-description).
 
 Verified building and running on Debian 12 (bookworm, GCC 12.2, ZFS 2.1.11)
 and CachyOS/Arch (GCC 16, ZFS 2.4.2).
@@ -62,6 +66,7 @@ If no poolname is specified, then all pools are sampled.
 | --execd | -e | For use with telegraf's `execd` plugin. When [enter] is pressed, the pools are sampled. To exit, use [ctrl+D] |
 | --no-histogram | -n | Do not print histogram information |
 | --sum-histogram-buckets | -s | Sum histogram bucket values |
+| --iostat-interval=SECONDS | -i | Also emit per-second pool I/O rates (the `zpool_iostat` measurement) by sampling twice, SECONDS apart, like `zpool iostat`. Adds SECONDS of latency per run (0 = disabled, default) |
 | --timeout=SECONDS | -t | Abort a sample that runs longer than SECONDS instead of overrunning the polling interval (0 = disabled, default). See [Caveat Emptor](#caveat-emptor) |
 | --lock-file=PATH | -l | Run at most one instance at a time. If another instance still holds PATH, exit immediately with no output instead of piling up. See [Caveat Emptor](#caveat-emptor) |
 | --help | -h | Print a short usage message |
@@ -93,6 +98,33 @@ The following measurements are collected:
 | zpool_io_size | per-vdev I/O size histogram | zpool iostat -r |
 | zpool_latency | per-vdev I/O latency histogram | zpool iostat -w |
 | zpool_vdev_queue | per-vdev instantaneous queue depth | zpool iostat -q |
+| zpool_iostat | per-second pool read/write throughput and IOPS (only with `--iostat-interval`) | zpool iostat |
+
+### zpool_iostat Description
+The cumulative `read_bytes`/`write_bytes`/`read_ops`/`write_ops` fields in
+`zpool_stats` are counters; the usual way to get a rate is to apply a
+derivative (e.g. influxdb's `non_negative_derivative`) at query time. As a
+convenience, `--iostat-interval=SECONDS` makes _zpool_influxdb_ compute the
+pool-level rates directly the same way `zpool iostat` does: it takes a second
+sample of the top-level vdev counters SECONDS later and divides the delta by
+the elapsed time. This adds SECONDS of latency to each run, so keep the
+interval shorter than your collection interval (and shorter than `--timeout`,
+if set). Rates are reported for the whole pool (`vdev=root`); counter resets
+are clamped to zero.
+
+#### zpool_iostat Tags
+| label | description |
+|---|---|
+| name | pool name |
+| vdev | always `root` (whole-pool totals) |
+
+#### zpool_iostat Fields
+| field | units | description |
+|---|---|---|
+| read_kib_per_sec | KiB/s | read throughput over the sample interval |
+| write_kib_per_sec | KiB/s | write throughput over the sample interval |
+| read_iops | ops/s | read operations per second over the interval |
+| write_iops | ops/s | write operations per second over the interval |
 
 ### zpool_stats Description
 zpool_stats contains top-level summary statistics for the pool.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 > **Note:** This is a fork of
 > [richardelling/zpool_influxdb](https://github.com/richardelling/zpool_influxdb).
-> It updates the original so it builds against modern OpenZFS releases
-> (verified on ZFS 2.1 / Debian 12 through ZFS 2.4) and recent
-> compilers/glibc. See [Changes in this fork](#changes-in-this-fork) for
-> details. All credit for the original program goes to Richard Elling.
+> It updates the original so it builds and runs on modern OpenZFS releases and
+> recent compilers/glibc. It is used on TrueNAS 26 (Community Edition) with
+> OpenZFS 2.4, and the source is verified from OpenZFS 2.1 (Debian 12) through
+> OpenZFS 2.4. See [Changes in this fork](#changes-in-this-fork) for details.
+> All credit for the original program goes to Richard Elling.
 
 The _zpool_influxdb_ program produces 
 [influxdb](https://github.com/influxdata/influxdb) line protocol
@@ -41,17 +42,15 @@ Relative to the upstream repository:
   default (`--iostat-interval=1`); pass `--iostat-interval=0` to disable. See
   [zpool_iostat Description](#zpool_iostat-description).
 
-Verified building and running on Debian 12 (bookworm, GCC 12.2, ZFS 2.1.11)
-and CachyOS/Arch (GCC 16, ZFS 2.4.2).
+Verified building on Debian 12 (bookworm, GCC 12.2, ZFS 2.1.11) and CachyOS
+(GCC 16, ZFS 2.4.2), and running on TrueNAS 26 (OpenZFS 2.4.1).
 
 ## ZFS Versions
-There are many implementations of ZFS on many OSes. The current
-version is tested to work on:
-* [ZFSonLinux](https://github.com/zfsonlinux/zfs) version 0.7 and later
-* [cstor](https://github.com/openebs/cstor) for userland ZFS (uZFS)
-
-This should compile and run on other ZFS versions, though many 
-do not have the latency histograms. Pull requests are welcome.
+ZFS on Linux is now part of [OpenZFS](https://github.com/openzfs/zfs). This
+fork is used on TrueNAS 26 (Community Edition) with OpenZFS 2.4, and the source
+is built and verified against OpenZFS 2.1 through 2.4. It should also compile
+and run on other OpenZFS releases, though some older versions lack the latency
+histograms. Pull requests are welcome.
 
 ## Usage
 When run without arguments, _zpool_influxdb_ runs once, reading data
@@ -187,8 +186,8 @@ The ZFS I/O (ZIO) scheduler uses five queues to schedule I/Os to each vdev.
 These queues are further divided into active and pending states.
 An I/O is pending prior to being issued to the vdev. An active
 I/O has been issued to the vdev. The scheduler and its tunable
-parameters are described at the 
-[ZFS on Linux wiki.](https://github.com/zfsonlinux/zfs/wiki/ZIO-Scheduler)
+parameters are described in the
+[OpenZFS documentation.](https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/ZIO%20Scheduler.html)
 The ZIO scheduler reports the queue depths as gauges where the value 
 represents an instantaneous snapshot of the queue depth at 
 the sample time. Therefore, it is not unusual to see all zeroes
@@ -399,7 +398,7 @@ be restarted to read the config-directory files.
   there are bugs in the kernel modules.
 
   A single wedged sample is a kernel-side condition that no user-space
-  program can reliably interrupt -- a thread stuck in an uninterruptible
+  program can reliably interrupt; a thread stuck in an uninterruptible
   `ioctl()` cannot be killed by a signal or a timeout. What you *can* avoid
   is letting frequent polling pile up many of these commands so they
   contend with each other and make matters worse. This fork adds two options

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ Relative to the upstream repository:
 * **Sensible defaults.** `ZFS_INSTALL_BASE` now defaults to `/usr` (matching
   distribution packages); override it for source installs.
 * **CPU target option.** A new `TARGET_ARCH` cmake variable controls `-march`
-  and defaults to `x86-64-v4`. See
-  [Target CPU architecture](#target-cpu-architecture).
+  and defaults to `x86-64-v4`, plus `STRIP_ISA_PROPERTY` for building on a
+  higher-ISA host than the target. See
+  [Target CPU architecture](#target-cpu-architecture) and
+  [Building on one machine to run on another](#building-on-one-machine-to-run-on-another).
 * **Frequent-polling safety options.** New `--lock-file` (run a single
   instance; skip overlapping invocations) and `--timeout` (bound a slow
   sample) options make frequent collection (e.g. telegraf every few seconds)
@@ -311,6 +313,34 @@ target a different level or a fully portable baseline, set _TARGET_ARCH_:
 cmake -D TARGET_ARCH=x86-64-v3 .   # AVX2 baseline
 cmake -D TARGET_ARCH= .             # compiler default (most portable)
 ```
+
+### Building on one machine to run on another
+`libzfs` is dynamically linked and has an unstable ABI, so a binary built on
+one machine has three requirements to run on another:
+
+1. **Matching OpenZFS version.** The binary links a specific `libzfs` SONAME
+   (`libzfs.so.4` for ZFS 2.1, `.so.6` for 2.2, `.so.7` for 2.4). The target
+   must have that same SONAME or it fails at startup with
+   `error while loading shared libraries: libzfs.so.N: cannot open shared
+   object file`. Build on (or against the headers/libs of) the **same OpenZFS
+   version the target runs**. For example, TrueNAS 26 runs ZFS 2.4
+   (`libzfs.so.7`), so build against ZFS 2.4, not Debian 12's ZFS 2.1.
+2. **glibc no newer than the target's.** The build host's glibc symbol
+   versions must be `<=` the target's. Check with
+   `objdump -T zpool_influxdb | grep -o 'GLIBC_[0-9.]*' | sort -V | tail -1`.
+3. **A CPU level the target supports.** Set `TARGET_ARCH` to the target's
+   level (see above). Note that on distro variants built for a high ISA level
+   (e.g. CachyOS's `x86-64-v4` repos), the toolchain stamps that level into
+   *every* binary via the startup objects, so the loader rejects it on a
+   lower CPU with `CPU ISA level is lower than required` even when
+   `TARGET_ARCH` is correct. Build with `-D STRIP_ISA_PROPERTY=ON` to remove
+   that gate:
+   ```bash
+   cmake -D TARGET_ARCH=x86-64-v3 -D STRIP_ISA_PROPERTY=ON .
+   make
+   ```
+   This only removes the inherited ISA *requirement* note; the emitted code
+   still uses no instructions above `TARGET_ARCH`.
 
 ## Installing
 Installation is left as an exercise for the reader because

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Relative to the upstream repository:
 * **CPU target option.** A new `TARGET_ARCH` cmake variable controls `-march`
   and defaults to `x86-64-v4`. See
   [Target CPU architecture](#target-cpu-architecture).
+* **Frequent-polling safety options.** New `--lock-file` (run a single
+  instance; skip overlapping invocations) and `--timeout` (bound a slow
+  sample) options make frequent collection (e.g. telegraf every few seconds)
+  safer. See [Caveat Emptor](#caveat-emptor).
 
 Verified building and running on Debian 12 (bookworm, GCC 12.2, ZFS 2.1.11)
 and CachyOS/Arch (GCC 16, ZFS 2.4.2).
@@ -56,6 +60,8 @@ If no poolname is specified, then all pools are sampled.
 | --execd | -e | For use with telegraf's `execd` plugin. When [enter] is pressed, the pools are sampled. To exit, use [ctrl+D] |
 | --no-histogram | -n | Do not print histogram information |
 | --sum-histogram-buckets | -s | Sum histogram bucket values |
+| --timeout=SECONDS | -t | Abort a sample that runs longer than SECONDS instead of overrunning the polling interval (0 = disabled, default). See [Caveat Emptor](#caveat-emptor) |
+| --lock-file=PATH | -l | Run at most one instance at a time. If another instance still holds PATH, exit immediately with no output instead of piling up. See [Caveat Emptor](#caveat-emptor) |
 | --help | -h | Print a short usage message |
 
 #### Histogram Bucket Values
@@ -327,13 +333,43 @@ be restarted to read the config-directory files.
   lock on spa_config for each imported pool. If this lock blocks,
   then the command will also block indefinitely and might be
   unkillable. This is not a normal condition, but can occur if 
-  there are bugs in the kernel modules. 
-  For this reason, care should be taken:
-  * avoid spawning many of these commands hoping that one might 
-    finish
-  * avoid frequent updates or short sample time
-    intervals, because the locks can interfere with the performance
-    of other instances of _zpool_ or _zpool_influxdb_
+  there are bugs in the kernel modules.
+
+  A single wedged sample is a kernel-side condition that no user-space
+  program can reliably interrupt -- a thread stuck in an uninterruptible
+  `ioctl()` cannot be killed by a signal or a timeout. What you *can* avoid
+  is letting frequent polling pile up many of these commands so they
+  contend with each other and make matters worse. This fork adds two options
+  to do exactly that:
+  * `--lock-file=PATH` runs at most one instance at a time. If a previous
+    sample is still running (or wedged), the next invocation exits
+    immediately with no output rather than spawning yet another process.
+  * `--timeout=SECONDS` bounds a sample so a slow-but-recoverable run does
+    not overrun the polling interval. (It cannot break a true kernel wedge,
+    but it handles the common slow/contended case.)
+
+### Recommended usage with telegraf
+When polling frequently (e.g. every few seconds), prefer the `execd` plugin:
+it starts a single long-lived process and samples on each trigger, so it does
+not spawn a new process every interval. Combine it with `--lock-file` and
+`--timeout` (and telegraf's own `timeout`) as belt-and-suspenders:
+```toml
+[[inputs.execd]]
+  command = ["/usr/bin/zpool_influxdb", "--execd",
+             "--lock-file=/run/zpool_influxdb.lock", "--timeout=4"]
+  signal = "STDIN"
+  data_format = "influx"
+```
+If you use the simpler `exec` plugin instead, set its `timeout` below your
+interval and still pass `--lock-file` so overlapping runs are skipped:
+```toml
+[[inputs.exec]]
+  commands = ["/usr/bin/zpool_influxdb --lock-file=/run/zpool_influxdb.lock"]
+  interval = "5s"
+  timeout = "4s"
+  data_format = "influx"
+```
+The lock file path must be writable by the user telegraf runs the command as.
 
 ## Other collectors
 There are a few other collectors for zpool statistics roaming around

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Relative to the upstream repository:
   instance; skip overlapping invocations) and `--timeout` (bound a slow
   sample) options make frequent collection (e.g. telegraf every few seconds)
   safer. See [Caveat Emptor](#caveat-emptor).
-* **Pool I/O rates.** New `--iostat-interval` option emits a `zpool_iostat`
-  measurement with per-second read/write throughput (KiB/s) and IOPS for the
-  pool, computed like `zpool iostat`. See
+* **Pool I/O rates.** A `zpool_iostat` measurement with per-second read/write
+  throughput (KiB/s) and IOPS for the pool, computed like `zpool iostat`. On by
+  default (`--iostat-interval=1`); pass `--iostat-interval=0` to disable. See
   [zpool_iostat Description](#zpool_iostat-description).
 
 Verified building and running on Debian 12 (bookworm, GCC 12.2, ZFS 2.1.11)
@@ -66,7 +66,7 @@ If no poolname is specified, then all pools are sampled.
 | --execd | -e | For use with telegraf's `execd` plugin. When [enter] is pressed, the pools are sampled. To exit, use [ctrl+D] |
 | --no-histogram | -n | Do not print histogram information |
 | --sum-histogram-buckets | -s | Sum histogram bucket values |
-| --iostat-interval=SECONDS | -i | Also emit per-second pool I/O rates (the `zpool_iostat` measurement) by sampling twice, SECONDS apart, like `zpool iostat`. Adds SECONDS of latency per run (0 = disabled, default) |
+| --iostat-interval=SECONDS | -i | Emit per-second pool I/O rates (the `zpool_iostat` measurement) by sampling twice, SECONDS apart, like `zpool iostat`. Adds SECONDS of latency per run. **Default 1**; pass `--iostat-interval=0` to disable |
 | --timeout=SECONDS | -t | Abort a sample that runs longer than SECONDS instead of overrunning the polling interval (0 = disabled, default). See [Caveat Emptor](#caveat-emptor) |
 | --lock-file=PATH | -l | Run at most one instance at a time. If another instance still holds PATH, exit immediately with no output instead of piling up. See [Caveat Emptor](#caveat-emptor) |
 | --help | -h | Print a short usage message |
@@ -98,19 +98,20 @@ The following measurements are collected:
 | zpool_io_size | per-vdev I/O size histogram | zpool iostat -r |
 | zpool_latency | per-vdev I/O latency histogram | zpool iostat -w |
 | zpool_vdev_queue | per-vdev instantaneous queue depth | zpool iostat -q |
-| zpool_iostat | per-second pool read/write throughput and IOPS (only with `--iostat-interval`) | zpool iostat |
+| zpool_iostat | per-second pool read/write throughput and IOPS (on by default; `--iostat-interval=0` disables) | zpool iostat |
 
 ### zpool_iostat Description
 The cumulative `read_bytes`/`write_bytes`/`read_ops`/`write_ops` fields in
 `zpool_stats` are counters; the usual way to get a rate is to apply a
 derivative (e.g. influxdb's `non_negative_derivative`) at query time. As a
-convenience, `--iostat-interval=SECONDS` makes _zpool_influxdb_ compute the
-pool-level rates directly the same way `zpool iostat` does: it takes a second
-sample of the top-level vdev counters SECONDS later and divides the delta by
-the elapsed time. This adds SECONDS of latency to each run, so keep the
-interval shorter than your collection interval (and shorter than `--timeout`,
-if set). Rates are reported for the whole pool (`vdev=root`); counter resets
-are clamped to zero.
+convenience, _zpool_influxdb_ also computes the pool-level rates directly the
+same way `zpool iostat` does: it takes a second sample of the top-level vdev
+counters `--iostat-interval` seconds later and divides the delta by the
+elapsed time. **This is on by default with a 1 second interval**, which adds
+~1 second of latency to each run; pass `--iostat-interval=0` to disable it, or
+a larger value to average over a longer window. Keep the interval shorter than
+your collection interval (and shorter than `--timeout`, if set). Rates are
+reported for the whole pool (`vdev=root`); counter resets are clamped to zero.
 
 #### zpool_iostat Tags
 | label | description |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,38 @@
 # Influxdb Metrics for ZFS Pools
+
+> **Note:** This is a fork of
+> [richardelling/zpool_influxdb](https://github.com/richardelling/zpool_influxdb).
+> It updates the original so it builds against modern OpenZFS releases
+> (verified on ZFS 2.1 / Debian 12 through ZFS 2.4) and recent
+> compilers/glibc. See [Changes in this fork](#changes-in-this-fork) for
+> details. All credit for the original program goes to Richard Elling.
+
 The _zpool_influxdb_ program produces 
 [influxdb](https://github.com/influxdata/influxdb) line protocol
 compatible metrics from zpools. In the UNIX tradition, _zpool_influxdb_
 does one thing: read statistics from a pool and print them to
 stdout. In many ways, this is a metrics-friendly output of 
 statistics normally observed via the `zpool` command.
+
+## Changes in this fork
+Relative to the upstream repository:
+* **Builds on modern OpenZFS.** The libzfs `nvlist_lookup_string()` signature
+  gained a `const` qualifier in OpenZFS 2.2. The build now detects the
+  signature at configure time, so the same source compiles cleanly on ZFS 2.1
+  (Debian 12's `char **`) and ZFS 2.2+ (`const char **`).
+* **Modern glibc fix.** Builds with `-D_LARGEFILE64_SOURCE` so the libspl
+  headers can use the transitional `stat64()`/`fstat64()` interfaces.
+* **Removed a stale scan field.** The `to_process` field was dropped from
+  `zpool_scan_stats`; the corresponding `pss_to_process` member no longer
+  exists in `pool_scan_stat_t`.
+* **Sensible defaults.** `ZFS_INSTALL_BASE` now defaults to `/usr` (matching
+  distribution packages); override it for source installs.
+* **CPU target option.** A new `TARGET_ARCH` cmake variable controls `-march`
+  and defaults to `x86-64-v4`. See
+  [Target CPU architecture](#target-cpu-architecture).
+
+Verified building and running on Debian 12 (bookworm, GCC 12.2, ZFS 2.1.11)
+and CachyOS/Arch (GCC 16, ZFS 2.4.2).
 
 ## ZFS Versions
 There are many implementations of ZFS on many OSes. The current
@@ -106,7 +134,6 @@ cannot be reported by this collector.
 | to_examine | bytes | prediction of total bytes to be scanned |
 | pass_examined | bytes | data examined during current scan pass |
 | processed | bytes | data reconstructed during scan |
-| to_process | bytes | total bytes to be repaired |
 | rate | bytes/sec | examination rate |
 | start_ts | epoch timestamp | start timestamp for scan |
 | pause_ts | epoch timestamp | timestamp for a scan pause request |
@@ -228,18 +255,56 @@ unsigned integers. To support unsigned, define SUPPORT_UINT64 and compile
 as described in `CMakeLists.txt`
 
 ## Building
-Building is simplified by using cmake.
-It is as simple as possible, but no simpler.
-By default, [ZFSonLinux](https://github.com/zfsonlinux/zfs) 
-installs the necessary header and library files in _/usr/local_.
-If you place those files elsewhere, either edit _CMakeLists.txt_ and
-change the _ZFS_INSTALL_BASE_ or pass it with `-D ZFS_INSTALL_BASE=/usr`
-on the cmake command line:
+Building uses cmake and needs a C compiler, the libzfs/libspl development
+headers, and the libzfs and libnvpair libraries.
+
+### 1. Install build dependencies
+
+Debian / Ubuntu (the ZFS packages are in `contrib`):
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential cmake libzfslinux-dev
+```
+
+Arch / CachyOS (ZFS is provided by the `zfs-dkms`/`zfs-utils` packages or the
+AUR; these install the libzfs headers):
+```bash
+sudo pacman -S --needed base-devel cmake zfs-utils
+```
+
+For a source install of [OpenZFS](https://github.com/openzfs/zfs), make sure
+`make install` placed the libzfs headers and libraries on the system.
+
+### 2. Configure and build
 ```bash
 cmake .
 make
 ```
-If successful, the _zpool_influxdb_ executable is created.
+If successful, the _zpool_influxdb_ executable is created in the current
+directory.
+
+Distribution packages install the headers and libraries under _/usr_, which is
+the default _ZFS_INSTALL_BASE_. A source install of OpenZFS defaults to
+_/usr/local_; in that case (or any other location) either edit _CMakeLists.txt_
+and change _ZFS_INSTALL_BASE_ or pass it on the cmake command line:
+```bash
+cmake -D ZFS_INSTALL_BASE=/usr/local .
+make
+```
+
+The libzfs API is unstable and has changed across OpenZFS releases. The build
+adapts at configure time (e.g. the `nvlist_lookup_string()` signature changed in
+OpenZFS 2.2) so the same source compiles on ZFS 2.1 (e.g. Debian 12) through
+current releases.
+
+### Target CPU architecture
+By default the binary is compiled for the `x86-64-v4` microarchitecture
+(AVX-512 baseline). Such a binary will not run on CPUs below that level. To
+target a different level or a fully portable baseline, set _TARGET_ARCH_:
+```bash
+cmake -D TARGET_ARCH=x86-64-v3 .   # AVX2 baseline
+cmake -D TARGET_ARCH= .             # compiler default (most portable)
+```
 
 ## Installing
 Installation is left as an exercise for the reader because

--- a/telegraf.d/zpool_influxdb.conf
+++ b/telegraf.d/zpool_influxdb.conf
@@ -1,15 +1,55 @@
-# # Read metrics from zpool_influxdb
+# Read ZFS pool metrics from zpool_influxdb.
+#
+# Drop this file into telegraf's config directory (often
+# /etc/telegraf/telegraf.d) and restart telegraf. zpool_influxdb prints
+# influxdb line-protocol metrics for every imported pool.
+# See https://github.com/Grassyloki/zpool_influxdb
+#
+# There are two ways to run it -- pick ONE. inputs.exec (below) is the simple
+# default; inputs.execd (commented out at the bottom) avoids spawning a new
+# process on every interval.
+#
+# NOTE: zpool_influxdb reads pool stats via libzfs, which generally requires
+# privileges (access to /dev/zfs). Make sure the user telegraf runs as can
+# read the pools and write the --lock-file path below.
+
 [[inputs.exec]]
-#   ## default installation location for zpool_influxdb command
-  commands = ["/usr/local/bin/zpool_influxdb"]
-#   ## Timeout for each command to complete.
-#   timeout = "5s"
-#
-#   ## measurement name suffix (for separating different commands)
-#   name_suffix = "_mycollector"
-#
-#   ## Data format to consume.
-#   ## Each data format has its own unique set of configuration options, read
-#   ## more about them here:
-#   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  ## Installed location of the binary, plus recommended options:
+  ##   --iostat-interval=1  Also emit the zpool_iostat measurement: per-second
+  ##                        read/write throughput (KiB/s) and IOPS. This is the
+  ##                        program's built-in default; it is shown here for
+  ##                        clarity. It samples the pool twice ~1s apart, so it
+  ##                        adds ~1s to each run. Pass --iostat-interval=0 to
+  ##                        turn it off and emit only the cumulative counters.
+  ##   --lock-file=PATH     Run at most one instance at a time. If a previous
+  ##                        sample is still running (or a pool is wedged on the
+  ##                        kernel side), the next run exits immediately with no
+  ##                        output instead of piling up more processes.
+  commands = ["/usr/local/bin/zpool_influxdb --iostat-interval=1 --lock-file=/run/zpool_influxdb.lock"]
+
+  ## How often telegraf runs the command. Keep this comfortably larger than
+  ## --iostat-interval (and larger than the timeout below).
+  interval = "10s"
+
+  ## Kill the command if it overruns; keep timeout < interval. Note a pool
+  ## wedged in the kernel cannot always be killed -- the --lock-file above is
+  ## what keeps a stuck run from spawning more. See "Caveat Emptor" in the README.
+  timeout = "8s"
+
+  ## measurement name suffix (for separating different commands)
+  # name_suffix = "_mycollector"
+
+  ## zpool_influxdb emits influxdb line protocol.
   data_format = "influx"
+
+# ## Alternative: inputs.execd starts ONE long-lived process and triggers a
+# ## sample whenever telegraf writes to its stdin, so it never spawns a new
+# ## process per interval (no pile-up by design). Use EITHER this block OR the
+# ## inputs.exec block above -- not both.
+# [[inputs.execd]]
+#   command = ["/usr/local/bin/zpool_influxdb", "--execd", "--iostat-interval=1", "--lock-file=/run/zpool_influxdb.lock"]
+#   ## telegraf writes a newline to stdin each interval to trigger a sample
+#   signal = "STDIN"
+#   ## restart the helper if it exits unexpectedly
+#   restart_delay = "10s"
+#   data_format = "influx"

--- a/telegraf.d/zpool_influxdb.conf
+++ b/telegraf.d/zpool_influxdb.conf
@@ -5,7 +5,7 @@
 # influxdb line-protocol metrics for every imported pool.
 # See https://github.com/Grassyloki/zpool_influxdb
 #
-# There are two ways to run it -- pick ONE. inputs.exec (below) is the simple
+# There are two ways to run it; pick ONE. inputs.exec (below) is the simple
 # default; inputs.execd (commented out at the bottom) avoids spawning a new
 # process on every interval.
 #
@@ -32,7 +32,7 @@
   interval = "10s"
 
   ## Kill the command if it overruns; keep timeout < interval. Note a pool
-  ## wedged in the kernel cannot always be killed -- the --lock-file above is
+  ## wedged in the kernel cannot always be killed; the --lock-file above is
   ## what keeps a stuck run from spawning more. See "Caveat Emptor" in the README.
   timeout = "8s"
 
@@ -45,7 +45,7 @@
 # ## Alternative: inputs.execd starts ONE long-lived process and triggers a
 # ## sample whenever telegraf writes to its stdin, so it never spawns a new
 # ## process per interval (no pile-up by design). Use EITHER this block OR the
-# ## inputs.exec block above -- not both.
+# ## inputs.exec block above, not both.
 # [[inputs.execd]]
 #   command = ["/usr/local/bin/zpool_influxdb", "--execd", "--iostat-interval=1", "--lock-file=/run/zpool_influxdb.lock"]
 #   ## telegraf writes a newline to stdin each interval to trigger a sample

--- a/zpool_influxdb.c
+++ b/zpool_influxdb.c
@@ -112,7 +112,8 @@ int no_histograms = 0;
 int sum_histogram_buckets = 0;
 int timeout_secs = 0;       /* watchdog timeout in seconds, 0 = disabled */
 char *lock_file = NULL;     /* single-instance lock file path, NULL = disabled */
-int iostat_interval = 0;    /* zpool-iostat sampling interval, 0 = disabled */
+int iostat_interval = 1;    /* zpool-iostat sampling interval (s); 0 disables.
+                             * Default 1 adds ~1s/run to emit zpool_iostat. */
 uint64_t timestamp = 0;
 
 /*

--- a/zpool_influxdb.c
+++ b/zpool_influxdb.c
@@ -58,6 +58,19 @@
 #include <string.h>
 #include <getopt.h>
 
+/*
+ * The third argument of nvlist_lookup_string() (and the string it returns)
+ * gained a const qualifier in OpenZFS 2.2. HAVE_CONST_NVLIST_LOOKUP_STRING is
+ * defined by CMake when building against the newer, const-correct headers.
+ * Use the matching type so the source compiles cleanly on both old (e.g.
+ * Debian 12 / ZFS 2.1) and new (ZFS >= 2.2) libzfs.
+ */
+#ifdef HAVE_CONST_NVLIST_LOOKUP_STRING
+typedef const char *nvstring_t;
+#else
+typedef char *nvstring_t;
+#endif
+
 #define POOL_MEASUREMENT        "zpool_stats"
 #define SCAN_MEASUREMENT        "zpool_scan_stats"
 #define VDEV_MEASUREMENT        "zpool_vdev_stats"
@@ -242,7 +255,7 @@ print_scan_status(nvlist_t *nvroot, const char *pool_name) {
 	              "pass_examined="IFMT",pause_ts="IFMT",paused_t="IFMT","
 	              "pct_done=%.2f,processed="IFMT",rate="IFMT","
 	              "remaining_t="IFMT",start_ts="IFMT","
-	              "to_examine="IFMT",to_process="IFMT" ",
+	              "to_examine="IFMT" ",
 	    MASK_UINT64(ps->pss_end_time),
 	    MASK_UINT64(ps->pss_errors),
 	    MASK_UINT64(examined),
@@ -254,8 +267,7 @@ print_scan_status(nvlist_t *nvroot, const char *pool_name) {
 	    MASK_UINT64(rate),
 	    MASK_UINT64(remaining_time),
 	    MASK_UINT64(ps->pss_start_time),
-	    MASK_UINT64(ps->pss_to_examine),
-	    MASK_UINT64(ps->pss_to_process)
+	    MASK_UINT64(ps->pss_to_examine)
 	);
 	(void) printf("%lu\n", timestamp);
 	return (0);
@@ -268,7 +280,7 @@ print_scan_status(nvlist_t *nvroot, const char *pool_name) {
 char *
 get_vdev_name(nvlist_t *nvroot, const char *parent_name) {
     static char vdev_name[256];
-    char *vdev_type = NULL;
+    nvstring_t vdev_type = NULL;
     uint64_t vdev_id = 0;
 
     if (nvlist_lookup_string(nvroot, ZPOOL_CONFIG_TYPE,
@@ -303,10 +315,10 @@ get_vdev_name(nvlist_t *nvroot, const char *parent_name) {
 char *
 get_vdev_desc(nvlist_t *nvroot, const char *parent_name) {
     static char vdev_desc[2 * MAXPATHLEN];
-    char *vdev_type = NULL;
+    nvstring_t vdev_type = NULL;
     uint64_t vdev_id = 0;
     char vdev_value[MAXPATHLEN];
-    char *vdev_path = NULL;
+    nvstring_t vdev_path = NULL;
     char *s, *t;
 
     if (nvlist_lookup_string(nvroot, ZPOOL_CONFIG_TYPE, &vdev_type) != 0) {
@@ -321,12 +333,12 @@ get_vdev_desc(nvlist_t *nvroot, const char *parent_name) {
     }
 
     if (parent_name == NULL) {
-        s = escape_string(vdev_type);
+        s = escape_string((char *)vdev_type);
         (void) snprintf(vdev_value, sizeof(vdev_value), "vdev=%s", s);
         free(s);
     } else {
         s = escape_string((char *)parent_name);
-        t = escape_string(vdev_type);
+        t = escape_string((char *)vdev_type);
         (void) snprintf(vdev_value, sizeof(vdev_value),
                         "vdev=%s/%s-%lu", s, t, vdev_id);
         free(s);
@@ -336,7 +348,7 @@ get_vdev_desc(nvlist_t *nvroot, const char *parent_name) {
         (void) snprintf(vdev_desc, sizeof(vdev_desc), "%s",
                         vdev_value);
     } else {
-        s = escape_string(vdev_path);
+        s = escape_string((char *)vdev_path);
         (void) snprintf(vdev_desc, sizeof(vdev_desc), "path=%s,%s",
                         s, vdev_value);
         free(s);

--- a/zpool_influxdb.c
+++ b/zpool_influxdb.c
@@ -85,6 +85,7 @@ typedef char *nvstring_t;
 #define MIN_LAT_INDEX        10  /* minimum latency index 10 = 1024ns */
 #define POOL_IO_SIZE_MEASUREMENT        "zpool_io_size"
 #define MIN_SIZE_INDEX        9  /* minimum size index 9 = 512 bytes */
+#define POOL_IOSTAT_MEASUREMENT "zpool_iostat"
 
 /*
  * telegraf 1.6.4 can handle uint64, which is the native ZFS type
@@ -111,6 +112,7 @@ int no_histograms = 0;
 int sum_histogram_buckets = 0;
 int timeout_secs = 0;       /* watchdog timeout in seconds, 0 = disabled */
 char *lock_file = NULL;     /* single-instance lock file path, NULL = disabled */
+int iostat_interval = 0;    /* zpool-iostat sampling interval, 0 = disabled */
 uint64_t timestamp = 0;
 
 /*
@@ -789,6 +791,73 @@ print_recursive_stats(stat_printer_f func, nvlist_t *nvroot,
 }
 
 /*
+ * Print per-second pool I/O rates, similar to `zpool iostat`.
+ *
+ * The vdev_stat_t counters (vs_ops, vs_bytes) are cumulative, so a rate
+ * requires two samples. We take a second sample of the top-level (root) vdev
+ * iostat_interval seconds after the first and divide the delta by the elapsed
+ * time reported by vs_timestamp (in nanoseconds), falling back to the
+ * requested interval if the timestamp did not advance. Counter resets (e.g. a
+ * pool re-import) are clamped to zero.
+ *
+ * o_* are the sample-1 values captured by the caller before sleeping.
+ */
+int
+print_pool_iostat(zpool_handle_t *zhp, const char *pool_name,
+                  uint64_t o_read_ops, uint64_t o_write_ops,
+                  uint64_t o_read_bytes, uint64_t o_write_bytes,
+                  uint64_t o_timestamp) {
+    uint_t c;
+    boolean_t missing;
+    nvlist_t *config, *nvroot;
+    vdev_stat_t *vs;
+    double elapsed;
+    struct timespec tv;
+
+    sleep((unsigned int) iostat_interval);
+
+    if (zpool_refresh_stats(zhp, &missing) != 0)
+        return (1);
+    config = zpool_get_config(zhp, NULL);
+    if (nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE, &nvroot) != 0)
+        return (2);
+    if (nvlist_lookup_uint64_array(nvroot, ZPOOL_CONFIG_VDEV_STATS,
+                                   (uint64_t **) &vs, &c) != 0)
+        return (3);
+
+    /* elapsed seconds, preferring the vdev's own timestamp */
+    if (vs->vs_timestamp > o_timestamp)
+        elapsed = (double) (vs->vs_timestamp - o_timestamp) / 1e9;
+    else
+        elapsed = (double) iostat_interval;
+    if (elapsed <= 0.0)
+        elapsed = (double) iostat_interval;
+
+#define IO_DELTA(new, old) (((new) > (old)) ? ((new) - (old)) : 0)
+    double read_kib = IO_DELTA(vs->vs_bytes[ZIO_TYPE_READ], o_read_bytes) /
+                      1024.0 / elapsed;
+    double write_kib = IO_DELTA(vs->vs_bytes[ZIO_TYPE_WRITE], o_write_bytes) /
+                       1024.0 / elapsed;
+    double read_iops = IO_DELTA(vs->vs_ops[ZIO_TYPE_READ], o_read_ops) /
+                       elapsed;
+    double write_iops = IO_DELTA(vs->vs_ops[ZIO_TYPE_WRITE], o_write_ops) /
+                        elapsed;
+#undef IO_DELTA
+
+    if (clock_gettime(CLOCK_REALTIME, &tv) != 0)
+        timestamp = (uint64_t) time(NULL) * 1000000000;
+    else
+        timestamp = ((uint64_t) tv.tv_sec * 1000000000) + (uint64_t) tv.tv_nsec;
+
+    (void) printf("%s,name=%s,vdev=root ", POOL_IOSTAT_MEASUREMENT, pool_name);
+    (void) printf("read_kib_per_sec=%.2f,write_kib_per_sec=%.2f,"
+                  "read_iops=%.2f,write_iops=%.2f",
+                  read_kib, write_kib, read_iops, write_iops);
+    (void) printf(" %lu\n", timestamp);
+    return (0);
+}
+
+/*
  * call-back to print the stats from the pool config
  *
  * Note: if the pool is broken, this can hang indefinitely and perhaps in an
@@ -833,6 +902,17 @@ print_stats(zpool_handle_t *zhp, void *data) {
 		return (3);
 	}
 
+	/*
+	 * Capture the root vdev's cumulative counters as the first iostat
+	 * sample; zpool_refresh_stats() in print_pool_iostat() will invalidate
+	 * this nvlist, so copy the scalars out now.
+	 */
+	uint64_t io_read_ops = vs->vs_ops[ZIO_TYPE_READ];
+	uint64_t io_write_ops = vs->vs_ops[ZIO_TYPE_WRITE];
+	uint64_t io_read_bytes = vs->vs_bytes[ZIO_TYPE_READ];
+	uint64_t io_write_bytes = vs->vs_bytes[ZIO_TYPE_WRITE];
+	uint64_t io_timestamp = vs->vs_timestamp;
+
 	pool_name = escape_string(zhp->zpool_name);
     err = print_recursive_stats(print_summary_stats, nvroot,
             pool_name, NULL, 1);
@@ -854,6 +934,14 @@ print_stats(zpool_handle_t *zhp, void *data) {
     if (err == 0)
         err = print_scan_status(nvroot, pool_name);
 
+    /*
+     * Must be last: print_pool_iostat() sleeps and refreshes the pool config,
+     * which invalidates nvroot.
+     */
+    if (err == 0 && iostat_interval > 0)
+        err = print_pool_iostat(zhp, pool_name, io_read_ops, io_write_ops,
+                                io_read_bytes, io_write_bytes, io_timestamp);
+
     free(pool_name);
     zpool_close(zhp);
 	return (err);
@@ -863,7 +951,7 @@ print_stats(zpool_handle_t *zhp, void *data) {
 void
 usage(char* name) {
     fprintf(stderr, "usage: %s [--execd][--no-histograms]"
-                    "[--sum-histogram-buckets]"
+                    "[--sum-histogram-buckets][--iostat-interval=SECONDS]"
                     "[--timeout=SECONDS][--lock-file=PATH] [poolname]\n", name);
     exit(EXIT_FAILURE);
 }
@@ -881,9 +969,10 @@ main(int argc, char *argv[]) {
         {"sum-histogram-buckets", no_argument, NULL, 's'},
         {"timeout", required_argument, NULL, 't'},
         {"lock-file", required_argument, NULL, 'l'},
+        {"iostat-interval", required_argument, NULL, 'i'},
         {0, 0, 0, 0}
     };
-    while ((opt = getopt_long(argc, argv, "ehnst:l:", long_options, NULL))
+    while ((opt = getopt_long(argc, argv, "ehnst:l:i:", long_options, NULL))
            != -1) {
         switch (opt) {
             case 'e':
@@ -902,6 +991,11 @@ main(int argc, char *argv[]) {
                 break;
             case 'l':
                 lock_file = optarg;
+                break;
+            case 'i':
+                iostat_interval = atoi(optarg);
+                if (iostat_interval < 0)
+                    iostat_interval = 0;
                 break;
             default:
                 usage(argv[0]);

--- a/zpool_influxdb.c
+++ b/zpool_influxdb.c
@@ -51,12 +51,18 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include <sys/types.h>
 #include <sys/fs/zfs.h>
 #include <libzfs.h>
 #include <string.h>
 #include <getopt.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <errno.h>
+#include <sys/file.h>
 
 /*
  * The third argument of nvlist_lookup_string() (and the string it returns)
@@ -103,7 +109,72 @@ typedef char *nvstring_t;
 int execd_mode = 0;
 int no_histograms = 0;
 int sum_histogram_buckets = 0;
+int timeout_secs = 0;       /* watchdog timeout in seconds, 0 = disabled */
+char *lock_file = NULL;     /* single-instance lock file path, NULL = disabled */
 uint64_t timestamp = 0;
+
+/*
+ * Watchdog: if a sample takes longer than timeout_secs, give up rather than
+ * overrunning the caller's polling interval. This bounds the common case of a
+ * slow or contended sample. Note: it cannot interrupt a thread wedged in an
+ * uninterruptible kernel ioctl (see "Caveat Emptor" in the README); such a
+ * process can linger until the kernel condition clears.
+ */
+static void
+timeout_handler(int sig) {
+    (void) sig;
+    static const char msg[] =
+        "error: zpool_influxdb sample timed out; pool may be unresponsive\n";
+    (void) write(STDERR_FILENO, msg, sizeof(msg) - 1);
+    _exit(EXIT_FAILURE);
+}
+
+static void
+arm_timeout(void) {
+    if (timeout_secs > 0)
+        (void) alarm((unsigned int) timeout_secs);
+}
+
+static void
+disarm_timeout(void) {
+    if (timeout_secs > 0)
+        (void) alarm(0);
+}
+
+/*
+ * Take a non-blocking exclusive lock on lock_file so that only one instance
+ * runs at a time. When zpool_influxdb is polled frequently (e.g. by telegraf
+ * every few seconds) and a sample runs long -- or wedges on an unresponsive
+ * pool -- this stops new invocations from piling up and contending with the
+ * stuck one. If the lock is already held, exit cleanly with no output so the
+ * caller simply records no data for this interval. If the lock file cannot be
+ * used we warn and continue rather than dropping samples.
+ */
+static void
+acquire_single_instance_lock(void) {
+    int fd;
+
+    if (lock_file == NULL)
+        return;
+
+    fd = open(lock_file, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
+    if (fd < 0) {
+        (void) fprintf(stderr, "warning: cannot open lock file %s: %s\n",
+                       lock_file, strerror(errno));
+        return;
+    }
+    if (flock(fd, LOCK_EX | LOCK_NB) != 0) {
+        if (errno == EWOULDBLOCK) {
+            /* another instance is still running; skip this sample */
+            exit(EXIT_SUCCESS);
+        }
+        (void) fprintf(stderr, "warning: cannot lock %s: %s\n",
+                       lock_file, strerror(errno));
+        (void) close(fd);
+        return;
+    }
+    /* leave fd open on purpose: the lock is held until this process exits */
+}
 int complained_about_sync = 0;
 
 /*
@@ -792,7 +863,8 @@ print_stats(zpool_handle_t *zhp, void *data) {
 void
 usage(char* name) {
     fprintf(stderr, "usage: %s [--execd][--no-histograms]"
-                    "[--sum-histogram-buckets] [poolname]\n", name);
+                    "[--sum-histogram-buckets]"
+                    "[--timeout=SECONDS][--lock-file=PATH] [poolname]\n", name);
     exit(EXIT_FAILURE);
 }
 
@@ -807,9 +879,12 @@ main(int argc, char *argv[]) {
         {"help", no_argument, NULL, 'h'},
         {"no-histograms", no_argument, NULL, 'n'},
         {"sum-histogram-buckets", no_argument, NULL, 's'},
+        {"timeout", required_argument, NULL, 't'},
+        {"lock-file", required_argument, NULL, 'l'},
         {0, 0, 0, 0}
     };
-    while ((opt = getopt_long(argc, argv, "ehns", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "ehnst:l:", long_options, NULL))
+           != -1) {
         switch (opt) {
             case 'e':
                 execd_mode = 1;
@@ -820,10 +895,27 @@ main(int argc, char *argv[]) {
             case 's':
                 sum_histogram_buckets = 1;
                 break;
+            case 't':
+                timeout_secs = atoi(optarg);
+                if (timeout_secs < 0)
+                    timeout_secs = 0;
+                break;
+            case 'l':
+                lock_file = optarg;
+                break;
             default:
                 usage(argv[0]);
         }
     }
+
+    /*
+     * Ensure only one instance runs at a time before doing any libzfs work,
+     * then install the watchdog. Both are no-ops unless the corresponding
+     * option was given.
+     */
+    acquire_single_instance_lock();
+    if (timeout_secs > 0)
+        (void) signal(SIGALRM, timeout_handler);
 
 	libzfs_handle_t *g_zfs;
 	if ((g_zfs = libzfs_init()) == NULL) {
@@ -833,11 +925,15 @@ main(int argc, char *argv[]) {
 		exit(EXIT_FAILURE);
 	}
 	if (execd_mode == 0) {
+        arm_timeout();
         ret = zpool_iter(g_zfs, print_stats, argv[optind]);
+        disarm_timeout();
         return (ret);
     }
     while (getline(&line, &len, stdin) != -1) {
+        arm_timeout();
         ret = zpool_iter(g_zfs, print_stats, argv[optind]);
+        disarm_timeout();
         fflush(stdout);
 	}
     return (ret);


### PR DESCRIPTION
## Summary
This updates `zpool_influxdb` so the same source builds and runs on current OpenZFS releases, adds options that make frequent polling (e.g. telegraf every few seconds) safer, and adds per-second pool I/O rate reporting. Five commits:

1. **Build against modern OpenZFS (2.1–2.4) and recent toolchains**
   - Detect the `nvlist_lookup_string()` `const` signature change (OpenZFS 2.2) at cmake configure time, so the same source compiles on ZFS 2.1 (`char **`) through 2.4 (`const char **`).
   - Build with `-D_LARGEFILE64_SOURCE` so libspl's `stat64()`/`fstat64()` work with modern glibc.
   - Drop the `to_process` scan field — `pss_to_process` no longer exists in `pool_scan_stat_t`.
   - Default `ZFS_INSTALL_BASE` to `/usr` (matches distribution packages); still overridable.

2. **`--lock-file` and `--timeout` for safe frequent polling**
   - `--lock-file=PATH`: non-blocking `flock` so only one instance runs at a time; if a prior sample is still running (or wedged), the new invocation exits cleanly instead of piling up.
   - `--timeout=SECONDS`: SIGALRM watchdog that aborts a slow-but-recoverable sample. (It cannot interrupt a true uninterruptible kernel ioctl — documented in Caveat Emptor.)
   - Both opt-in.

3. **`TARGET_ARCH` / `STRIP_ISA_PROPERTY` cmake options** for selecting the CPU target and for building on one machine to run on another.

4. **`--iostat-interval`: per-second pool I/O rates**
   - Adds a `zpool_iostat` measurement with `read_kib_per_sec`, `write_kib_per_sec`, `read_iops`, `write_iops` for the pool, computed like `zpool iostat` (a second sample of the top-level vdev counters, divided by elapsed `vs_timestamp`). Counter resets clamped to zero.

5. **Default `--iostat-interval` to 1s; ship a commented telegraf config**
   - The `zpool_iostat` rates are now emitted by default (1s sample window); `--iostat-interval=0` disables them.
   - `telegraf.d/zpool_influxdb.conf` rewritten with explanatory comments (an `inputs.exec` block plus a commented `inputs.execd` alternative).

## Testing
Verified building and running on:
- **Debian 12** (bookworm, GCC 12.2, OpenZFS 2.1.11, `libzfs.so.4`)
- **CachyOS** (GCC 16, OpenZFS 2.4.2, `libzfs.so.7`)
- **TrueNAS 26** (AMD EPYC 7D12, OpenZFS 2.4.1, glibc 2.41) — emits metrics for the live pool, and the `zpool_iostat` rates match `zpool iostat -y` over the same window.

## Notes
A few items lean toward my fork's preferences and I'm happy to tailor them to match upstream conventions — e.g. whether `--iostat-interval` should default on, the default `TARGET_ARCH`, the `STRIP_ISA_PROPERTY` option, and README wording. Just let me know and I'll adjust.
